### PR TITLE
Security: Potential denial of service via extremely large retry loops on filesystem errors

### DIFF
--- a/src/io_scene_vrm/common/fs.py
+++ b/src/io_scene_vrm/common/fs.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: MIT OR GPL-3.0-or-later
-import sys
 from pathlib import Path
 from typing import Optional
 
 
 def create_unique_indexed_directory_path(path: Path) -> Path:
     name = path.name
-    for count in range(sys.maxsize):
+    max_retry_count = 1000
+    for count in range(max_retry_count):
         count_str = f".{count}" if count else ""
         path = path.with_name(name + count_str)
         try:
             path.mkdir(parents=True)
-        except OSError:
+        except FileExistsError:
             continue
+        except OSError as exception:
+            message = f"Failed to create unique directory path: {path}"
+            raise RuntimeError(message) from exception
         return path
     message = f"Failed to create unique directory path: {path}"
     raise RuntimeError(message)
@@ -21,21 +24,33 @@ def create_unique_indexed_directory_path(path: Path) -> Path:
 def create_unique_indexed_file_path(path: Path, binary: Optional[bytes] = None) -> Path:
     suffix = path.suffix
     stem = path.stem
-    for count in range(sys.maxsize):
+    max_retry_count = 1000
+    for count in range(max_retry_count):
         count_str = f".{count}" if count else ""
         path = path.with_name(stem + count_str + suffix)
 
         if binary is None:
-            if not path.exists():
-                return path
+            try:
+                if not path.exists():
+                    return path
+            except OSError as exception:
+                message = f"Failed to create unique file path: {path}"
+                raise RuntimeError(message) from exception
             continue
 
         try:
             path.touch(exist_ok=False)
-        except OSError:
+        except FileExistsError:
             continue
+        except OSError as exception:
+            message = f"Failed to create unique file path: {path}"
+            raise RuntimeError(message) from exception
 
-        path.write_bytes(binary)
+        try:
+            path.write_bytes(binary)
+        except OSError as exception:
+            message = f"Failed to create unique file path: {path}"
+            raise RuntimeError(message) from exception
         return path
 
     message = f"Failed to create unique file path: {path}"


### PR DESCRIPTION
## Summary

Security: Potential denial of service via extremely large retry loops on filesystem errors

## Problem

**Severity**: `Low` | **File**: `src/io_scene_vrm/common/fs.py:L7`

Both unique path helper functions iterate up to `sys.maxsize` on repeated `OSError`. If the parent directory is unwritable or otherwise consistently failing, these loops can run for a very long time and consume CPU, effectively hanging the process.

## Solution

Set a practical retry limit (e.g., 1000 attempts), detect non-recoverable errors early (permission denied, invalid path), and fail fast with a clear exception.

## Changes

- `src/io_scene_vrm/common/fs.py` (modified)